### PR TITLE
Let browser handle modified click events

### DIFF
--- a/esm/index.js
+++ b/esm/index.js
@@ -83,11 +83,18 @@ const app = Class ? Class.app : freeze({
   }
 });
 
+const isModifiedEvent = ({metaKey, altKey, ctrlKey, shiftKey}) =>
+  !!(metaKey || altKey || ctrlKey || shiftKey);
+
 const ARoute = Class || class ARoute extends HTMLAnchorElement {
   static get app() { return app; }
   connectedCallback() { this.addEventListener('click', this); }
   disconnectedCallback() { this.removeEventListener('click', this); }
   handleEvent(event) {
+    // Let the browser handle modified click events (ctrl-click etc.)
+    if (isModifiedEvent(event))
+      return;
+
     event.preventDefault();
     if (this.hasAttribute('no-propagation'))
       event.stopPropagation();


### PR DESCRIPTION
Hi :wave: 

Am trying to create a React wrapper for `a-route` because I'd like to avoid using the popular react packages if I can, so far so good :)
I have noticed that `a-route` doesn't include the fix for modified click events on `a-route` links, thus not allowing the user to open links in new window/tab using common keyboard combinations such as `ctrl-click`.

Basically, re-applying https://github.com/WebReflection/onpushstate/pull/1

Allows for correctly opening links a new tab/window when pressing shift/command/control key while clicking a `a-route` link.

Thanks for taking this fix in consideration, and as always, for your work on these open source libraries.